### PR TITLE
Revert "Configure preview image to be blog image"

### DIFF
--- a/blog/2023-05-19-how-10101-app-protects-you/index.md
+++ b/blog/2023-05-19-how-10101-app-protects-you/index.md
@@ -5,10 +5,6 @@ authors: [daniel]
 tags: [self-custodial, trading, knowledge-base]
 ---
 
-<head>
-  <meta name="og:image" content="10101_app_empowerment.png" />
-</head>
-
 In a [previous blogpost](./../2023-05-11-10101-trade-settlement.md) we talked about self-custodial settlement paths in 10101.
 In this blogpost we explore how the 10101 app will enable you to stay self-sovereign in your self-custodial trade setup.
 


### PR DESCRIPTION
Reverts get10101/10101.github.io#36

Unfortunately this did not work - the image cannot be found like this.
Probably we need to construct the path to point to the image.

Not investing more time into this for now because I already fixed the default social card to look better, see #37 