### PR TITLE
Increase recent blog posts to 10

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,9 +43,10 @@ const config = {
         docs: false,
         blog: {
           showReadingTime: true,
-          // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl: "https://github.com/get10101/10101.github.io",
+          // Sets the number of blog posts shown in recent blog posts.
+          blogSidebarCount: 10,
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
We can also always show all blog posts.  For now lets go with 10 and see how it looks like when we have more than 10 blog posts.