### PR TITLE
Update index.html

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -502,7 +502,7 @@
               >
                 <!-- Featured Icon -->
                 <div class="featured-icon mb-3">
-                  <i class="material-icons md-72">stacks</i>
+                  <i class="material-icons md-72">bolt</i>
                 </div>
                 <!-- Icon Text -->
                 <div class="icon-text">


### PR DESCRIPTION
-> APPSTORES links were inverted according to this report: https://x.com/1sats_ln/status/1759049363748429987

-> I took the opportunity to get rid of the mentions of Lightning on the page